### PR TITLE
Improve mobile skills lightbox sizing

### DIFF
--- a/portfolio/src/pages/Skills.css
+++ b/portfolio/src/pages/Skills.css
@@ -739,7 +739,8 @@
   .skills-lightbox {
     inset: 3vh 3vw;
     grid-template-columns: 1fr;
-    grid-template-rows: auto auto;
+    grid-template-rows: minmax(0, 1fr) auto;
+    max-height: 94vh;
   }
 
   .skills-lightbox-nav {
@@ -752,6 +753,19 @@
     border-left: 0;
     border-top: 1px solid var(--border);
     padding: 1.25rem 0.35rem 0.2rem;
+  }
+
+  .skills-lightbox-stage {
+    min-height: 0;
+    height: min(58vh, 100%);
+  }
+
+  .skills-lightbox-image,
+  .skills-lightbox.is-tall .skills-lightbox-image {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
   }
 
   .writing-panel {
@@ -800,6 +814,8 @@
     inset: 0;
     border-radius: 0;
     padding: 0.9rem;
+    max-height: 100vh;
+    grid-template-rows: minmax(0, 1fr) auto;
   }
 
   .skills-lightbox-nav-prev {
@@ -812,6 +828,14 @@
 
   .skills-lightbox-title {
     font-size: 1.6rem;
+  }
+
+  .skills-lightbox-stage {
+    height: min(54vh, 100%);
+  }
+
+  .skills-lightbox-copy {
+    padding-bottom: 0.4rem;
   }
 
   .writing-cards-grid {


### PR DESCRIPTION
## Summary
- adjust the skills lightbox layout on smaller screens so the stage can shrink within the viewport
- constrain image sizing on mobile to avoid overflow for tall figures
- tighten mobile copy spacing and lightbox height behavior for narrow viewports

## Testing
- not run (CSS-only change)
